### PR TITLE
fix: reveal career content on place switch

### DIFF
--- a/src/components/views/CareerView.vue
+++ b/src/components/views/CareerView.vue
@@ -19,7 +19,7 @@
           </button>
         </div>
 
-        <Transition name="fade" mode="out-in">
+        <Transition name="fade" mode="out-in" @enter="revealContent">
           <div class="active-place-content" :key="currentPlaceIndex">
             <div class="title">
               <span>{{ currentPlace.role }} at </span>
@@ -124,10 +124,19 @@ const setPlaceAsActive = (index) => {
   nextTick(centerActiveChip)
 }
 
+const revealContent = (content) => {
+  reveal(
+    content.children,
+    { opacity: 0, y: 20 },
+    { opacity: 1, y: 0 },
+    { duration: 500, stagger: 100 }
+  )
+}
+
 const animateElement = () => {
   const heading = document.querySelectorAll('#career .section-heading > *')
   const placesButtons = document.querySelectorAll('.buttons-container > *')
-  const placeInfos = document.querySelectorAll('.active-place-content > *')
+  const content = document.querySelector('.active-place-content')
 
   reveal(
     heading,
@@ -143,12 +152,7 @@ const animateElement = () => {
     { duration: 500, stagger: 100 }
   )
 
-  reveal(
-    placeInfos,
-    { opacity: 0, y: 20 },
-    { opacity: 1, y: 0 },
-    { duration: 500, stagger: 100 }
-  )
+  if (content) revealContent(content)
 }
 
 onMounted(() => {


### PR DESCRIPTION
## Problem
In the Career section, selecting any place other than HiPeople rendered a blank content area - the title/period/description sat at \`opacity: 0\`.

## Root cause
The content reveal animation ran only once, in \`animateElement\` (fired on scroll-intersection), animating \`.active-place-content > *\` from \`opacity: 0\` to \`1\` with \`fill: 'both'\`. The content lives inside \`<Transition mode="out-in">\` keyed on \`currentPlaceIndex\`, so switching chips mounts fresh child elements that never received the reveal - leaving them stuck at \`opacity: 0\`. HiPeople worked only because it's the initial index the one-time reveal targeted.

## Fix
- Extracted the content reveal into a \`revealContent(content)\` helper.
- Wired it to the Transition's \`@enter\` hook so new content is revealed on every place switch.
- Initial scroll-in reveal still uses the same helper, so first-load behavior is unchanged.

## Verification
Drove the page with Playwright and cycled through all six places - each now animates in and settles at \`opacity: 1\`.

*AI used to help with the code